### PR TITLE
disabling animations instead of sleeping

### DIFF
--- a/test/perceptual/d2l-grade-result-autograde-provided.visual-diff.js
+++ b/test/perceptual/d2l-grade-result-autograde-provided.visual-diff.js
@@ -15,6 +15,7 @@ describe('autograde provided visual diff tests', () => {
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/test/perceptual/d2l-grade-result-autograde-provided.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
+		await visualDiff.disableAnimations(page);
 	});
 
 	beforeEach(async() => {

--- a/test/perceptual/d2l-grade-result-read-only.visual-diff.js
+++ b/test/perceptual/d2l-grade-result-read-only.visual-diff.js
@@ -15,6 +15,7 @@ describe('read only visual diff tests', () => {
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/test/perceptual/d2l-grade-result-read-only.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
+		await visualDiff.disableAnimations(page);
 	});
 
 	beforeEach(async() => {

--- a/test/perceptual/d2l-grade-result-write-enabled.visual-diff.js
+++ b/test/perceptual/d2l-grade-result-write-enabled.visual-diff.js
@@ -15,6 +15,7 @@ describe('write enabled visual diff tests', () => {
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/test/perceptual/d2l-grade-result-write-enabled.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
+		await visualDiff.disableAnimations(page);
 	});
 
 	beforeEach(async() => {

--- a/test/perceptual/d2l-grade-result.visual-diff.js
+++ b/test/perceptual/d2l-grade-result.visual-diff.js
@@ -15,6 +15,7 @@ describe('d2l-labs-d2l-grade-result', () => {
 		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
 		await page.goto(`${visualDiff.getBaseUrl()}/test/perceptual/d2l-grade-result.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
 		await page.bringToFront();
+		await visualDiff.disableAnimations(page);
 	});
 
 	beforeEach(async() => {

--- a/test/perceptual/utils.js
+++ b/test/perceptual/utils.js
@@ -28,10 +28,6 @@ async function testDiff(visualDiff, page, id, fullTitle, focusGrades = false, fo
 		await focusReportsButton(page, id);
 	}
 
-	if (focusGrades || focusReports) {
-		await new Promise((resolve) => setTimeout(resolve, 200));
-	}
-
 	await visualDiff.screenshotAndCompare(page, fullTitle, { clip: rect });
 }
 


### PR DESCRIPTION
I wanted to attempt to see if disabling animations had the same effect as sleeping for these tests. It seems as though they did.