### PR TITLE
fixed error on decimal values

### DIFF
--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -54,6 +54,7 @@ export class D2LGradeResultNumericScore extends LitElement {
 							aria-label="Grade Score"
 							value="${this.scoreNumerator}"
 							min="0"
+							step="any"
 							@change=${this._onGradeChange}
 						></d2l-input-text>
 					</div>


### PR DESCRIPTION
There was previously an issue where if you entered a decimal value in as a numeric grade, the input would glow red. This red glow does not occur anymore.

![image](https://user-images.githubusercontent.com/20796985/81220901-12c2e500-8fb0-11ea-9fb5-dc73b876585c.png)
