### PR TITLE
fix letter grade init

### DIFF
--- a/src/components/d2l-grade-result.js
+++ b/src/components/d2l-grade-result.js
@@ -195,8 +195,8 @@ export class D2LGradeResult extends LocalizeMixin(LitElement) {
 				.gradeType=${this._grade.getScoreType()}
 				scoreNumerator=${this._grade.getScore()}
 				scoreDenominator=${this._grade.getScoreOutOf()}
-				.letterGradeOptions=${this._grade.getScore()}
-				selectedLetterGrade=${this._grade.getScoreOutOf()}
+				.letterGradeOptions=${this._grade.getScoreOutOf()}
+				selectedLetterGrade=${this._grade.getScore()}
 				.customManualOverrideText=${this.customManualOverrideText}
 				.customManualOverrideClearText=${this.customManualOverrideClearText}
 


### PR DESCRIPTION
Initializing a letter type _grade with `letterGradeOptions` was using the wrong methods, this fix switches the methods to the correct ones.