### PR TITLE
bypassing d2l-input-text validation

### DIFF
--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -54,6 +54,7 @@ export class D2LGradeResultNumericScore extends LitElement {
 							aria-label="Grade Score"
 							value="${this.scoreNumerator}"
 							min="0"
+							novalidate
 							step="any"
 							@change=${this._onGradeChange}
 						></d2l-input-text>


### PR DESCRIPTION
`d2l-input-text` is about to have validation enabled, which will suddenly start checking for min/max/required. Since we're not sure how this will impact places that weren't expecting it, we're disabling it for now.

Eventually, this numeric input should use the in-development `d2l-input-number`.