### PR TITLE
Add calculated score to determine overridden grade

### DIFF
--- a/src/components/d2l-grade-result-presentational.js
+++ b/src/components/d2l-grade-result-presentational.js
@@ -22,7 +22,6 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 			gradeButtonTooltip: { type: String },
 			reportsButtonTooltip: { type: String },
 			readOnly: { type: Boolean },
-			isGradeAutoCompleted: { type: Boolean },
 			isManualOverrideActive: { type: Boolean },
 			hideTitle: { type: Boolean },
 			customManualOverrideClearText: { type: String },
@@ -55,7 +54,6 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 		this.includeGradeButton = false;
 		this.includeReportsButton = false;
 		this.selectedLetterGrade = '';
-		this.isGradeAutoCompleted = false;
 		this.isManualOverrideActive = false;
 		this.hideTitle = false;
 		this.customManualOverrideClearText = undefined;
@@ -98,9 +96,6 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	_isReadOnly() {
-		if (this.isGradeAutoCompleted && !this.isManualOverrideActive) {
-			return true;
-		}
 		return Boolean(this.readOnly);
 	}
 
@@ -136,7 +131,7 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	_renderManualOverrideButtonComponent() {
-		if (this.isGradeAutoCompleted && this.isManualOverrideActive) {
+		if (this.isManualOverrideActive) {
 
 			const text = this.customManualOverrideClearText ? this.customManualOverrideClearText : this.localize('clearManualOverride');
 			const icon = 'tier1:close-default';

--- a/src/controller/Grade.js
+++ b/src/controller/Grade.js
@@ -16,8 +16,10 @@ export const GradeErrors = {
 
 export class Grade {
 
-	constructor(scoreType, score, outOf, letterGrade, letterGradeOptions, entity) {
+	constructor(scoreType, score, outOf, letterGrade, letterGradeOptions, entity, calculatedScore = null) {
 		this.entity = entity;
+		this.isManuallyOverridden = false;
+		this.calculatedScore = calculatedScore;
 		this.scoreType = this._parseScoreType(scoreType);
 		if (this.isNumberGrade()) {
 			this._parseNumberGrade(score, outOf);
@@ -116,6 +118,10 @@ export class Grade {
 
 		if (typeof outOf === 'string') {
 			outOf = Number(outOf);
+		}
+
+		if (this.calculatedScore !== null) {
+			this.isManuallyOverridden = score !== this.calculatedScore;
 		}
 
 		this.score = score;

--- a/test/Grade.test.js
+++ b/test/Grade.test.js
@@ -19,6 +19,26 @@ describe('Grade tests', () => {
 			assert.equal(grade.getScoreOutOf(), 50);
 		});
 
+		it('initializes properly for a numeric score (not overridden)', () => {
+			const grade = new Grade(GradeType.Number, 10, 50, null, null, null, 10);
+			assert.equal(grade.isLetterGrade(), false);
+			assert.equal(grade.isNumberGrade(), true);
+			assert.equal(grade.getScoreType(), GradeType.Number);
+			assert.equal(grade.getScore(), 10);
+			assert.equal(grade.getScoreOutOf(), 50);
+			assert.equal(grade.isManuallyOverridden, false);
+		});
+
+		it('initializes properly for a numeric score (overridden)', () => {
+			const grade = new Grade(GradeType.Number, 10, 50, null, null, null, 15);
+			assert.equal(grade.isLetterGrade(), false);
+			assert.equal(grade.isNumberGrade(), true);
+			assert.equal(grade.getScoreType(), GradeType.Number);
+			assert.equal(grade.getScore(), 10);
+			assert.equal(grade.getScoreOutOf(), 50);
+			assert.equal(grade.isManuallyOverridden, true);
+		});
+
 		it('initializes properly for a letter score', () => {
 			const grade = new Grade(GradeType.Letter, null, null, 'A', letterGradeOptions);
 			assert.equal(grade.isLetterGrade(), true);


### PR DESCRIPTION
Determine the state of overridden grade with the new `calculatedScore`

- Add calculatedScore to Grade Constructor
- Add constructor tests and isManuallyOverridden tests
- Remove `this.isGradeAutoCompleted` from presentational