### PR TITLE
US137887 - add property for score validation

### DIFF
--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -57,9 +57,9 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 		} else {
 			inputNumberLabel = this.localize('fullGradeScoreLabel', { numerator: roundedNumerator || 'blank', denominator: this.scoreDenominator });
 		}
-		console.log('IN GRADE-RESULT-NUMERIC score = ', this.scoreNumerator, ' validationError = ', this.validationError, typeof this.validationError);
+
 		this.isValid = !this.validationError || typeof this.validationError === undefined || this.validationError === '';
-		console.log('this.isValid ? ', this.isValid);
+
 		return html`
 			<div class="d2l-grade-result-numeric-score-container">
 

--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -12,7 +12,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 			scoreDenominator: { type: Number },
 			readOnly: { type: Boolean },
 			validationError: { attribute: false, type: String },
-			isValid: { attribute: false, type: Boolean }
+			isValidScore: { attribute: false, type: Boolean }
 		};
 	}
 
@@ -58,7 +58,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 			inputNumberLabel = this.localize('fullGradeScoreLabel', { numerator: roundedNumerator || 'blank', denominator: this.scoreDenominator });
 		}
 
-		this.isValid = !this.validationError || typeof this.validationError === undefined || this.validationError === '';
+		this.isValidScore = !this.validationError || typeof this.validationError === undefined;
 
 		return html`
 			<div class="d2l-grade-result-numeric-score-container">
@@ -75,7 +75,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 								max="9999999999"
 								max-fraction-digits="2"
 								@change=${this._onGradeChange}
-								?validate-on-init=${this.isValid}
+								?validate-on-init=${this.isValidScore}
 							></d2l-input-number>
 							<d2l-validation-custom
 								for="grade-input"
@@ -100,7 +100,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 	}
 
 	_checkValidationError(event,) {
-		event.detail.resolve(this.isValid);
+		event.detail.resolve(this.isValidScore);
 	}
 
 	_onGradeChange(e) {

--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -99,7 +99,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	_checkValidationError(event,) {
+	_checkValidationError(event) {
 		event.detail.resolve(this.isValidScore);
 	}
 

--- a/src/components/d2l-grade-result-numeric-score.js
+++ b/src/components/d2l-grade-result-numeric-score.js
@@ -11,7 +11,8 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 			scoreNumerator: { type: Number },
 			scoreDenominator: { type: Number },
 			readOnly: { type: Boolean },
-			validationError: { attribute: false, type: String }
+			validationError: { attribute: false, type: String },
+			isValid: { attribute: false, type: Boolean }
 		};
 	}
 
@@ -56,6 +57,9 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 		} else {
 			inputNumberLabel = this.localize('fullGradeScoreLabel', { numerator: roundedNumerator || 'blank', denominator: this.scoreDenominator });
 		}
+		console.log('IN GRADE-RESULT-NUMERIC score = ', this.scoreNumerator, ' validationError = ', this.validationError, typeof this.validationError);
+		this.isValid = !this.validationError || typeof this.validationError === undefined || this.validationError === '';
+		console.log('this.isValid ? ', this.isValid);
 		return html`
 			<div class="d2l-grade-result-numeric-score-container">
 
@@ -71,7 +75,7 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 								max="9999999999"
 								max-fraction-digits="2"
 								@change=${this._onGradeChange}
-								?validate-on-init=${this.validationError}
+								?validate-on-init=${this.isValid}
 							></d2l-input-number>
 							<d2l-validation-custom
 								for="grade-input"
@@ -95,8 +99,8 @@ export class D2LGradeResultNumericScore extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	_checkValidationError(event) {
-		event.detail.resolve(!this.validationError);
+	_checkValidationError(event,) {
+		event.detail.resolve(this.isValid);
 	}
 
 	_onGradeChange(e) {

--- a/src/components/d2l-grade-result-presentational.js
+++ b/src/components/d2l-grade-result-presentational.js
@@ -61,7 +61,6 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	render() {
-		console.log('rendering grade result');
 		return html`
 			<div>
 				${this._renderTitle()}
@@ -151,7 +150,6 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	_renderNumericScoreComponent() {
-		console.log('IN GRADE-RESULT _renderNumericScoreComponent');
 		return html`
 			<d2l-grade-result-numeric-score
 				.scoreNumerator=${this.scoreNumerator}

--- a/src/components/d2l-grade-result-presentational.js
+++ b/src/components/d2l-grade-result-presentational.js
@@ -61,6 +61,7 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	render() {
+		console.log('rendering grade result');
 		return html`
 			<div>
 				${this._renderTitle()}
@@ -150,6 +151,7 @@ export class D2LGradeResultPresentational extends LocalizeMixin(LitElement) {
 	}
 
 	_renderNumericScoreComponent() {
+		console.log('IN GRADE-RESULT _renderNumericScoreComponent');
 		return html`
 			<d2l-grade-result-numeric-score
 				.scoreNumerator=${this.scoreNumerator}


### PR DESCRIPTION
Related to [US137887 - [Consistent Evaluation][Quizzing][UI] Update question and attempt score to not support null](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F631329991735)

Previously, if a user entered an invalid score/no score followed by a valid score, the `d2l-validation-custom`  in `d2l-grade-result-numeric-score` would continue to render the invalid score error. This PR adds a property (`this.isValidScore`) which allows us to check if the current score is valid each time the component renders.